### PR TITLE
[codex] cache revalidated pages for cloudflare workers

### DIFF
--- a/notion.sync.api.client/.vscode/settings.json
+++ b/notion.sync.api.client/.vscode/settings.json
@@ -20,5 +20,6 @@
   "[javascriptreact]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/notion.sync.api.client/public/sitemap-0.xml
+++ b/notion.sync.api.client/public/sitemap-0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>http://localhost:3000/contact</loc><lastmod>2026-04-18T03:06:29.943Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/blog</loc><lastmod>2026-04-18T03:06:29.945Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/tag</loc><lastmod>2026-04-18T03:06:29.945Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000</loc><lastmod>2026-04-18T03:06:29.945Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/contact</loc><lastmod>2026-04-18T17:21:10.701Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/tag</loc><lastmod>2026-04-18T17:21:10.701Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/blog</loc><lastmod>2026-04-18T17:21:10.701Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000</loc><lastmod>2026-04-18T17:21:10.701Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/notion.sync.api.client/src/app/blog/page.tsx
+++ b/notion.sync.api.client/src/app/blog/page.tsx
@@ -1,9 +1,6 @@
-import { supabase } from "@/utils/supabase/server";
-import { ArticlesType } from "@/type/api.type";
+import { getAllArticles } from "@/utils/supabase/server";
 import ArticleList from "@/components/ArticleList";
 import type { Metadata } from "next";
-
-export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "最新技术分享",
@@ -26,9 +23,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Blog() {
-  const { data } = await supabase
-    .rpc("get_all_articles")
-    .overrideTypes<ArticlesType[]>();
+  const data = await getAllArticles();
 
   const articleData = Array.isArray(data) ? data : [];
 

--- a/notion.sync.api.client/src/app/page.tsx
+++ b/notion.sync.api.client/src/app/page.tsx
@@ -1,5 +1,4 @@
-import { GetTagsAndRecommendArticlesResponseType } from "@/type/api.type";
-import { supabase } from "@/utils/supabase/server";
+import { getTagsAndRecommendArticles } from "@/utils/supabase/server";
 import Image from "next/image";
 import MyAvatar from "../../public/avatar.jpg";
 import LucideIcon from "@/components/LucideIcon";
@@ -7,12 +6,8 @@ import dynamicIconImports from "lucide-react/dynamicIconImports";
 import ArticleList from "@/components/ArticleList";
 import Link from "next/link";
 
-export const revalidate = 3600;
-
 export default async function AppPage() {
-  const { data } = await supabase
-    .rpc("get_tags_and_recommend_articles")
-    .single<GetTagsAndRecommendArticlesResponseType>();
+  const data = await getTagsAndRecommendArticles();
 
   const tags = Array.isArray(data?.tags) ? data?.tags : [];
   const recommendArticles = Array.isArray(data?.recommendArticles)

--- a/notion.sync.api.client/src/app/tag/page.tsx
+++ b/notion.sync.api.client/src/app/tag/page.tsx
@@ -1,9 +1,6 @@
-import { supabase } from "@/utils/supabase/server";
-import { GetTagsWithArticlesResponseType } from "@/type/api.type";
+import { getTagsWithArticles } from "@/utils/supabase/server";
 import MenuList from "@/components/tag/MenuList";
 import type { Metadata } from "next";
-
-export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "所有标签",
@@ -27,9 +24,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Tag() {
-  const { data: tagsData } = await supabase
-    .rpc("get_tags_with_articles_json")
-    .overrideTypes<GetTagsWithArticlesResponseType[]>();
+  const tagsData = await getTagsWithArticles();
 
   const tags = Array.isArray(tagsData) ? tagsData : [];
 

--- a/notion.sync.api.client/src/utils/supabase/server.ts
+++ b/notion.sync.api.client/src/utils/supabase/server.ts
@@ -3,6 +3,8 @@ import { createClient } from "@supabase/supabase-js";
 import { unstable_cache } from "next/cache";
 import {
   GetArticleWithSubTagsResponseType,
+  GetTagsAndRecommendArticlesResponseType,
+  GetTagsWithArticlesResponseType,
   TagsType,
   ArticlesType,
 } from "@/type/api.type";
@@ -13,6 +15,42 @@ export const supabase = createClient(
 );
 
 const CACHE_REVALIDATE = 3600;
+
+export const getTagsAndRecommendArticles = unstable_cache(
+  async () => {
+    const { data } = await supabase
+      .rpc("get_tags_and_recommend_articles")
+      .single<GetTagsAndRecommendArticlesResponseType>();
+
+    return data ?? null;
+  },
+  ["home-data"],
+  { revalidate: CACHE_REVALIDATE },
+);
+
+export const getAllArticles = unstable_cache(
+  async () => {
+    const { data } = await supabase
+      .rpc("get_all_articles")
+      .overrideTypes<ArticlesType[]>();
+
+    return data ?? null;
+  },
+  ["article-list"],
+  { revalidate: CACHE_REVALIDATE },
+);
+
+export const getTagsWithArticles = unstable_cache(
+  async () => {
+    const { data } = await supabase
+      .rpc("get_tags_with_articles_json")
+      .overrideTypes<GetTagsWithArticlesResponseType[]>();
+
+    return data ?? null;
+  },
+  ["tag-list"],
+  { revalidate: CACHE_REVALIDATE },
+);
 
 export const getArticleWithSubTags = unstable_cache(
   async (slug: string) => {


### PR DESCRIPTION
## What changed
- moved the home, blog list, and tag list data fetching behind `unstable_cache` helpers in `src/utils/supabase/server.ts`
- updated `src/app/page.tsx`, `src/app/blog/page.tsx`, and `src/app/tag/page.tsx` to use those cached helpers instead of relying on `export const revalidate = 3600`
- included the current workspace updates to `.vscode/settings.json` and the regenerated `public/sitemap-0.xml`

## Why
The project was migrated from Vercel to Cloudflare Workers, and page-level `export const revalidate = 3600` no longer provided the intended compatibility for these routes. This change follows the existing `getArticleWithSubTags` and `getTagDetailWithArticles` pattern so the cache behavior is defined at the Supabase RPC layer instead.

## Impact
- `/`, `/blog`, and `/tag` regain 1 hour revalidation in the build output
- the Cloudflare/OpenNext build path uses the same compatibility approach as the existing article and tag detail fetches

## Validation
- `pnpm lint src/utils/supabase/server.ts src/app/page.tsx src/app/blog/page.tsx src/app/tag/page.tsx`
- `pnpm build`
- `pnpm cf:build`

## Notes
- `pnpm build` still reports the pre-existing ESLint warnings in `src/hooks/useLongPress.ts`
- the Cloudflare build still emits the existing local `NEXT_CACHE_DO_QUEUE` / `DOQueueHandler` warnings, but the build completes successfully