### PR TITLE
[codex] tune opennext isr queue

### DIFF
--- a/notion.sync.api.client/src/app/blog/[tag]/[slug]/page.tsx
+++ b/notion.sync.api.client/src/app/blog/[tag]/[slug]/page.tsx
@@ -9,7 +9,7 @@ type PageProps = {
   params: Promise<{ tag: string; slug: string }>;
 };
 
-export const revalidate = 300;
+export const revalidate = 14400;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];

--- a/notion.sync.api.client/src/app/blog/page.tsx
+++ b/notion.sync.api.client/src/app/blog/page.tsx
@@ -2,7 +2,7 @@ import { getAllArticles } from "@/utils/blog-cache/server";
 import ArticleList from "@/components/ArticleList";
 import type { Metadata } from "next";
 
-export const revalidate = 120;
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "最新技术分享",

--- a/notion.sync.api.client/src/app/page.tsx
+++ b/notion.sync.api.client/src/app/page.tsx
@@ -6,7 +6,7 @@ import dynamicIconImports from "lucide-react/dynamicIconImports";
 import ArticleList from "@/components/ArticleList";
 import Link from "next/link";
 
-export const revalidate = 120;
+export const revalidate = 3600;
 
 export default async function AppPage() {
   const data = await getTagsAndRecommendArticles();

--- a/notion.sync.api.client/src/app/tag/[tag]/page.tsx
+++ b/notion.sync.api.client/src/app/tag/[tag]/page.tsx
@@ -5,7 +5,7 @@ type PageProps = {
   params: Promise<{ tag: string }>;
 };
 
-export const revalidate = 120;
+export const revalidate = 14400;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];

--- a/notion.sync.api.client/src/app/tag/page.tsx
+++ b/notion.sync.api.client/src/app/tag/page.tsx
@@ -2,7 +2,7 @@ import { getTagsWithArticles } from "@/utils/blog-cache/server";
 import MenuList from "@/components/tag/MenuList";
 import type { Metadata } from "next";
 
-export const revalidate = 120;
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "所有标签",

--- a/notion.sync.api.client/wrangler.jsonc
+++ b/notion.sync.api.client/wrangler.jsonc
@@ -4,6 +4,12 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-04-15",
   "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    "NEXT_CACHE_DO_QUEUE_MAX_REVALIDATION": "1",
+    "MAX_REVALIDATE_CONCURRENCY": "1",
+    "NEXT_CACHE_DO_QUEUE_RETRY_INTERVAL_MS": "60000",
+    "NEXT_CACHE_DO_QUEUE_MAX_RETRIES": "3"
+  },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary

- Increase OpenNext ISR revalidate intervals to better match the 4-hour Notion-to-KV publish cycle.
- Limit `NEXT_CACHE_DO_QUEUE` concurrency and retry pressure for the Cloudflare Free plan.
- Keep OpenNext ISR, R2 incremental cache, and Durable Object queue enabled.

## Why

The previous 120s/300s ISR intervals could trigger frequent background revalidation even though the source KV data only refreshes every 4 hours. On Cloudflare Free, repeated DO queue retries can consume too many subrequests in a single invocation.

## Validation

- `pnpm lint` passed with 0 errors and existing warnings.
- `wrangler.jsonc` parsed successfully as JSON.
- `pnpm cf:build` reached successful Next compile/type/static generation, then failed locally on Windows symlink creation during OpenNext traced-file copy with `EPERM`; this appears environment-related and not caused by these changes.