### PR TITLE
Make aggregate pages dynamic

### DIFF
--- a/notion.sync.api.client/src/app/blog/page.tsx
+++ b/notion.sync.api.client/src/app/blog/page.tsx
@@ -2,7 +2,7 @@ import { getAllArticles } from "@/utils/blog-cache/server";
 import ArticleList from "@/components/ArticleList";
 import type { Metadata } from "next";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "最新技术分享",

--- a/notion.sync.api.client/src/app/page.tsx
+++ b/notion.sync.api.client/src/app/page.tsx
@@ -6,7 +6,7 @@ import dynamicIconImports from "lucide-react/dynamicIconImports";
 import ArticleList from "@/components/ArticleList";
 import Link from "next/link";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export default async function AppPage() {
   const data = await getTagsAndRecommendArticles();

--- a/notion.sync.api.client/src/app/tag/[tag]/page.tsx
+++ b/notion.sync.api.client/src/app/tag/[tag]/page.tsx
@@ -5,11 +5,7 @@ type PageProps = {
   params: Promise<{ tag: string }>;
 };
 
-export const revalidate = 14400;
-export const dynamicParams = true;
-export async function generateStaticParams() {
-  return [];
-}
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({ params }: PageProps) {
   const { tag } = await params;

--- a/notion.sync.api.client/src/app/tag/page.tsx
+++ b/notion.sync.api.client/src/app/tag/page.tsx
@@ -2,7 +2,7 @@ import { getTagsWithArticles } from "@/utils/blog-cache/server";
 import MenuList from "@/components/tag/MenuList";
 import type { Metadata } from "next";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "所有标签",

--- a/notion.sync.api.client/wrangler.jsonc
+++ b/notion.sync.api.client/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-04-15",
   "compatibility_flags": ["nodejs_compat"],
+  "keep_vars": true,
   "vars": {
     "NEXT_CACHE_DO_QUEUE_MAX_REVALIDATION": "1",
     "MAX_REVALIDATE_CONCURRENCY": "1",


### PR DESCRIPTION
## Summary

- Make the homepage, blog list, tag list, and tag detail list render dynamically instead of using ISR page cache.
- Keep article detail pages on long ISR caching.
- Add `keep_vars` to Wrangler config so deploys do not wipe dashboard-managed plain vars while retaining the OpenNext queue tuning vars.

## Why

The previous ISR settings could cache an empty aggregate page if the production KV data was unavailable during build or revalidation. Dynamic rendering keeps aggregate pages reading the current `BLOG_CACHE` contents while preserving ISR for article detail pages.

## Validation

- `pnpm lint`
- `pnpm build`

Build output confirmed `/`, `/blog`, `/tag`, and `/tag/[tag]` are dynamic, while `/blog/[tag]/[slug]` remains SSG/ISR.